### PR TITLE
fix(ci): use native ARM64 runner for Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
     name: Build Docker Image (ARM64)
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     needs: [test, security_audit]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm  # Native ARM64 runner - avoids QEMU emulation issues
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Switch ARM64 Docker build from QEMU emulation to native ARM64 runner.

## Problem

The ARM64 Docker build fails intermittently due to QEMU emulation issues with Alpine's `apk` package manager. The busybox triggers fail with `execve: No such file or directory` (error 127).

## Solution

Use GitHub's native ARM64 runner (`ubuntu-24.04-arm`) instead of emulating ARM64 on x86_64.

## Changes

- `docker_arm64` job: `runs-on: ubuntu-latest` → `runs-on: ubuntu-24.04-arm`