### PR TITLE
fix: honor server bind_address and CLI -c/--controller

### DIFF
--- a/openfanctl/src/cli/handlers.rs
+++ b/openfanctl/src/cli/handlers.rs
@@ -11,19 +11,16 @@ use crate::format::format_success;
 
 use super::commands::*;
 
-/// Default controller ID used when controller is not specified in port format.
-const DEFAULT_CONTROLLER_ID: &str = "default";
-
 /// Error message when neither --pwm nor --rpm is specified.
 const ERR_PWM_OR_RPM_REQUIRED: &str = "Must specify either --pwm or --rpm";
 
 /// Parse zone port specifications into ZoneFan entries.
 ///
 /// Supports two formats:
-/// - Simple: "0,1,2" (uses "default" controller)
+/// - Simple: "0,1,2" (uses `default_controller` for unqualified ports)
 /// - Controller-qualified: "main:0,main:1,gpu:0"
-/// - Mixed: "0,1,gpu:2" (plain numbers use "default" controller)
-fn parse_zone_ports(ports: &str) -> Result<Vec<ZoneFan>> {
+/// - Mixed: "0,1,gpu:2" (plain numbers use `default_controller`)
+fn parse_zone_ports(ports: &str, default_controller: &str) -> Result<Vec<ZoneFan>> {
     let mut fans = Vec::new();
 
     for part in ports.split(',') {
@@ -39,11 +36,11 @@ fn parse_zone_ports(ports: &str) -> Result<Vec<ZoneFan>> {
                 .map_err(|_| anyhow::anyhow!("Invalid fan ID '{}' in '{}'", fan_id_str, part))?;
             fans.push(ZoneFan::new(controller, fan_id));
         } else {
-            // Simple format: just a number, uses default controller
+            // Simple format: just a number, uses the default controller
             let fan_id: u8 = part
                 .parse()
                 .map_err(|_| anyhow::anyhow!("Invalid port specification '{}'", part))?;
-            fans.push(ZoneFan::new(DEFAULT_CONTROLLER_ID, fan_id));
+            fans.push(ZoneFan::new(default_controller, fan_id));
         }
     }
 
@@ -430,7 +427,7 @@ pub async fn handle_zone(
             ports,
             description,
         } => {
-            let fans = parse_zone_ports(&ports)?;
+            let fans = parse_zone_ports(&ports, client.controller_id())?;
             client.add_zone(&name, fans, description).await?;
             println!("{}", format_success(&format!("Added zone: {}", name)));
         }
@@ -439,7 +436,7 @@ pub async fn handle_zone(
             ports,
             description,
         } => {
-            let fans = parse_zone_ports(&ports)?;
+            let fans = parse_zone_ports(&ports, client.controller_id())?;
             client.update_zone(&name, fans, description).await?;
             println!("{}", format_success(&format!("Updated zone: {}", name)));
         }
@@ -1326,7 +1323,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_simple_format() {
-        let result = super::parse_zone_ports("0,1,2").unwrap();
+        let result = super::parse_zone_ports("0,1,2", "default").unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].controller, "default");
         assert_eq!(result[0].fan_id, 0);
@@ -1338,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_qualified_format() {
-        let result = super::parse_zone_ports("main:0,main:1,gpu:0").unwrap();
+        let result = super::parse_zone_ports("main:0,main:1,gpu:0", "default").unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].controller, "main");
         assert_eq!(result[0].fan_id, 0);
@@ -1350,7 +1347,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_mixed_format() {
-        let result = super::parse_zone_ports("0,gpu:2,1").unwrap();
+        let result = super::parse_zone_ports("0,gpu:2,1", "default").unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].controller, "default");
         assert_eq!(result[0].fan_id, 0);
@@ -1362,7 +1359,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_with_whitespace() {
-        let result = super::parse_zone_ports(" 0 , 1 , main:2 ").unwrap();
+        let result = super::parse_zone_ports(" 0 , 1 , main:2 ", "default").unwrap();
         assert_eq!(result.len(), 3);
         assert_eq!(result[0].controller, "default");
         assert_eq!(result[0].fan_id, 0);
@@ -1373,8 +1370,21 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_zone_ports_uses_supplied_default_controller() {
+        // Unqualified ports honor the supplied default (e.g. set via -c).
+        let result = super::parse_zone_ports("0,1,gpu:2", "main").unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].controller, "main");
+        assert_eq!(result[0].fan_id, 0);
+        assert_eq!(result[1].controller, "main");
+        assert_eq!(result[1].fan_id, 1);
+        assert_eq!(result[2].controller, "gpu");
+        assert_eq!(result[2].fan_id, 2);
+    }
+
+    #[test]
     fn test_parse_zone_ports_empty_fails() {
-        let result = super::parse_zone_ports("");
+        let result = super::parse_zone_ports("", "default");
         assert!(result.is_err());
         assert!(
             result
@@ -1386,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_invalid_number_fails() {
-        let result = super::parse_zone_ports("0,abc,2");
+        let result = super::parse_zone_ports("0,abc,2", "default");
         assert!(result.is_err());
         assert!(
             result
@@ -1398,7 +1408,7 @@ mod tests {
 
     #[test]
     fn test_parse_zone_ports_invalid_qualified_format_fails() {
-        let result = super::parse_zone_ports("main:abc");
+        let result = super::parse_zone_ports("main:abc", "default");
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Invalid fan ID"));
     }

--- a/openfanctl/src/client.rs
+++ b/openfanctl/src/client.rs
@@ -56,11 +56,13 @@ pub struct OpenFanClient {
     max_retries: u32,
     retry_delay: Duration,
     board_info: BoardInfo,
+    /// Controller ID used for all controller-scoped API routes.
+    controller_id: String,
 }
 
 impl OpenFanClient {
-    /// Default controller ID used for all controller-scoped API routes.
-    const DEFAULT_CONTROLLER: &'static str = "default";
+    /// Default controller ID used when none is specified.
+    pub const DEFAULT_CONTROLLER: &'static str = "default";
 
     /// Get the board information for the connected server.
     ///
@@ -69,6 +71,19 @@ impl OpenFanClient {
     /// Returns the board info fetched during client initialization.
     pub fn board_info(&self) -> &BoardInfo {
         &self.board_info
+    }
+
+    /// Get the controller ID this client targets for controller-scoped routes.
+    pub fn controller_id(&self) -> &str {
+        &self.controller_id
+    }
+
+    /// Override the controller ID this client targets.
+    ///
+    /// Useful for selecting a specific controller in multi-controller setups.
+    pub fn with_controller(mut self, controller_id: impl Into<String>) -> Self {
+        self.controller_id = controller_id.into();
+        self
     }
 
     /// Create a new OpenFAN client with custom configuration.
@@ -118,6 +133,7 @@ impl OpenFanClient {
                 max_target_rpm: 9000,
                 baud_rate: 115200,
             },
+            controller_id: Self::DEFAULT_CONTROLLER.to_string(),
         };
 
         // Fetch board info from server
@@ -132,6 +148,7 @@ impl OpenFanClient {
             max_retries,
             retry_delay,
             board_info: info.board_info,
+            controller_id: Self::DEFAULT_CONTROLLER.to_string(),
         })
     }
 
@@ -250,9 +267,9 @@ impl OpenFanClient {
         let url = format!(
             "{}/api/v0/controller/{}/fan/status",
             self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.controller_id
         );
-        let endpoint = "controller/default/fan/status";
+        let endpoint = &format!("controller/{}/fan/status", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -270,9 +287,9 @@ impl OpenFanClient {
         let url = format!(
             "{}/api/v0/controller/{}/fan/status",
             self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.controller_id
         );
-        let endpoint = "controller/default/fan/status";
+        let endpoint = &format!("controller/{}/fan/status", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -292,11 +309,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/fan/{}/rpm/get",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id
+            self.base_url, self.controller_id, fan_id
         );
-        let endpoint = &format!("controller/default/fan/{}/rpm/get", fan_id);
+        let endpoint = &format!("controller/{}/fan/{}/rpm/get", self.controller_id, fan_id);
 
         let rpm: u32 = self
             .execute_with_retry(endpoint, || self.client.get(&url).send())
@@ -325,12 +340,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/fan/{}/pwm?value={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id,
-            pwm
+            self.base_url, self.controller_id, fan_id, pwm
         );
-        let endpoint = &format!("controller/default/fan/{}/pwm", fan_id);
+        let endpoint = &format!("controller/{}/fan/{}/pwm", self.controller_id, fan_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -357,12 +369,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/fan/{}/rpm?value={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id,
-            rpm
+            self.base_url, self.controller_id, fan_id, rpm
         );
-        let endpoint = &format!("controller/default/fan/{}/rpm", fan_id);
+        let endpoint = &format!("controller/{}/fan/{}/rpm", self.controller_id, fan_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -377,10 +386,9 @@ impl OpenFanClient {
     pub async fn get_profiles(&self) -> Result<api::ProfileResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/profiles/list",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
-        let endpoint = "controller/default/profiles/list";
+        let endpoint = &format!("controller/{}/profiles/list", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -405,11 +413,9 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/profiles/set?name={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name
+            self.base_url, self.controller_id, encoded_name
         );
-        let endpoint = "controller/default/profiles/set";
+        let endpoint = &format!("controller/{}/profiles/set", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -443,14 +449,13 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/profiles/add",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
         let mut request_body = HashMap::new();
         request_body.insert("name", serde_json::Value::String(name.to_string()));
         request_body.insert("profile", serde_json::to_value(profile)?);
 
-        let endpoint = "controller/default/profiles/add";
+        let endpoint = &format!("controller/{}/profiles/add", self.controller_id);
 
         let response = self
             .client
@@ -482,11 +487,9 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/profiles/remove?name={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name
+            self.base_url, self.controller_id, encoded_name
         );
-        let endpoint = "controller/default/profiles/remove";
+        let endpoint = &format!("controller/{}/profiles/remove", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -501,10 +504,9 @@ impl OpenFanClient {
     pub async fn get_aliases(&self) -> Result<api::AliasResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/alias/all/get",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
-        let endpoint = "controller/default/alias/all/get";
+        let endpoint = &format!("controller/{}/alias/all/get", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -524,11 +526,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/alias/{}/get",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id
+            self.base_url, self.controller_id, fan_id
         );
-        let endpoint = &format!("controller/default/alias/{}/get", fan_id);
+        let endpoint = &format!("controller/{}/alias/{}/get", self.controller_id, fan_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -562,12 +562,9 @@ impl OpenFanClient {
         let encoded_alias = alias.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/alias/{}/set?value={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id,
-            encoded_alias
+            self.base_url, self.controller_id, fan_id, encoded_alias
         );
-        let endpoint = &format!("controller/default/alias/{}/set", fan_id);
+        let endpoint = &format!("controller/{}/alias/{}/set", self.controller_id, fan_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -590,11 +587,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/alias/{}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            fan_id
+            self.base_url, self.controller_id, fan_id
         );
-        let endpoint = &format!("controller/default/alias/{}", fan_id);
+        let endpoint = &format!("controller/{}/alias/{}", self.controller_id, fan_id);
 
         self.execute_with_retry(endpoint, || self.client.delete(&url).send())
             .await
@@ -830,10 +825,9 @@ impl OpenFanClient {
     pub async fn get_curves(&self) -> Result<api::ThermalCurveResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/curves/list",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
-        let endpoint = "controller/default/curves/list";
+        let endpoint = &format!("controller/{}/curves/list", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -856,11 +850,9 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/curve/{}/get",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name
+            self.base_url, self.controller_id, encoded_name
         );
-        let endpoint = &format!("controller/default/curve/{}/get", name);
+        let endpoint = &format!("controller/{}/curve/{}/get", self.controller_id, name);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -892,8 +884,7 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/curves/add",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
         let mut request_body = HashMap::new();
         request_body.insert("name", serde_json::Value::String(name.to_string()));
@@ -902,7 +893,7 @@ impl OpenFanClient {
             request_body.insert("description", serde_json::Value::String(desc));
         }
 
-        let endpoint = "controller/default/curves/add";
+        let endpoint = &format!("controller/{}/curves/add", self.controller_id);
 
         let response = self
             .client
@@ -944,9 +935,7 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/curve/{}/update",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name
+            self.base_url, self.controller_id, encoded_name
         );
         let mut request_body = HashMap::new();
         request_body.insert("points", serde_json::to_value(&points)?);
@@ -954,7 +943,7 @@ impl OpenFanClient {
             request_body.insert("description", serde_json::Value::String(desc));
         }
 
-        let endpoint = &format!("controller/default/curve/{}/update", name);
+        let endpoint = &format!("controller/{}/curve/{}/update", self.controller_id, name);
 
         let response = self
             .client
@@ -986,11 +975,9 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/curve/{}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name
+            self.base_url, self.controller_id, encoded_name
         );
-        let endpoint = &format!("controller/default/curve/{}", name);
+        let endpoint = &format!("controller/{}/curve/{}", self.controller_id, name);
 
         self.execute_with_retry(endpoint, || self.client.delete(&url).send())
             .await
@@ -1025,12 +1012,12 @@ impl OpenFanClient {
         let encoded_name = name.replace(' ', "%20").replace('&', "%26");
         let url = format!(
             "{}/api/v0/controller/{}/curve/{}/interpolate?temp={}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            encoded_name,
-            temp
+            self.base_url, self.controller_id, encoded_name, temp
         );
-        let endpoint = &format!("controller/default/curve/{}/interpolate", name);
+        let endpoint = &format!(
+            "controller/{}/curve/{}/interpolate",
+            self.controller_id, name
+        );
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -1048,10 +1035,9 @@ impl OpenFanClient {
     pub async fn get_cfm_mappings(&self) -> Result<api::CfmListResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/cfm/list",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER
+            self.base_url, self.controller_id
         );
-        let endpoint = "controller/default/cfm/list";
+        let endpoint = &format!("controller/{}/cfm/list", self.controller_id);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -1071,11 +1057,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/cfm/{}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            port
+            self.base_url, self.controller_id, port
         );
-        let endpoint = &format!("controller/default/cfm/{}", port);
+        let endpoint = &format!("controller/{}/cfm/{}", self.controller_id, port);
 
         self.execute_with_retry(endpoint, || self.client.get(&url).send())
             .await
@@ -1106,12 +1090,10 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/cfm/{}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            port
+            self.base_url, self.controller_id, port
         );
         let request = api::SetCfmRequest { cfm_at_100 };
-        let endpoint = &format!("controller/default/cfm/{}", port);
+        let endpoint = &format!("controller/{}/cfm/{}", self.controller_id, port);
 
         let response = self
             .client
@@ -1140,11 +1122,9 @@ impl OpenFanClient {
 
         let url = format!(
             "{}/api/v0/controller/{}/cfm/{}",
-            self.base_url,
-            Self::DEFAULT_CONTROLLER,
-            port
+            self.base_url, self.controller_id, port
         );
-        let endpoint = &format!("controller/default/cfm/{}", port);
+        let endpoint = &format!("controller/{}/cfm/{}", self.controller_id, port);
 
         self.execute_with_retry(endpoint, || self.client.delete(&url).send())
             .await

--- a/openfanctl/src/client.rs
+++ b/openfanctl/src/client.rs
@@ -266,8 +266,7 @@ impl OpenFanClient {
     pub async fn get_fan_status(&self) -> Result<api::FanStatusResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/fan/status",
-            self.base_url,
-            self.controller_id
+            self.base_url, self.controller_id
         );
         let endpoint = &format!("controller/{}/fan/status", self.controller_id);
 
@@ -286,8 +285,7 @@ impl OpenFanClient {
     pub async fn get_fan_status_by_id(&self, _fan_id: u8) -> Result<api::FanStatusResponse> {
         let url = format!(
             "{}/api/v0/controller/{}/fan/status",
-            self.base_url,
-            self.controller_id
+            self.base_url, self.controller_id
         );
         let endpoint = &format!("controller/{}/fan/status", self.controller_id);
 

--- a/openfanctl/src/main.rs
+++ b/openfanctl/src/main.rs
@@ -89,6 +89,12 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Apply -c/--controller override for controller-scoped routes.
+    let client = match cli.controller.as_deref() {
+        Some(id) => client.with_controller(id),
+        None => client,
+    };
+
     if verbose {
         eprintln!("Successfully connected to server");
         eprintln!(

--- a/openfanctl/tests/e2e_integration_tests.rs
+++ b/openfanctl/tests/e2e_integration_tests.rs
@@ -15,6 +15,8 @@ use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, BufReader as TokioBufReader};
+use tokio::process::Command as TokioCommand;
 use tokio::sync::Mutex;
 use tokio::time::{sleep, timeout};
 
@@ -1796,3 +1798,103 @@ async fn test_e2e_zone_with_controller_format() -> Result<()> {
     harness.stop_server().await?;
     Ok(())
 }
+
+// =============================================================================
+// Regression tests
+// =============================================================================
+
+/// Pick a unique port for a standalone test that does not use `E2ETestHarness`.
+///
+/// Uses the same recipe as the harness: combine process id, thread id, and
+/// the current nanosecond to spread tests apart even when run in parallel.
+fn pick_unique_port(base: u16) -> u16 {
+    let process_id = std::process::id();
+    let thread_id = std::thread::current().id();
+    let thread_hash = format!("{:?}", thread_id)
+        .chars()
+        .filter(|c| c.is_ascii_digit())
+        .collect::<String>();
+    let thread_num = thread_hash.parse::<u32>().unwrap_or(0);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    base + ((process_id + thread_num + nanos) % 1000) as u16
+}
+
+/// Regression test for issue #67.
+///
+/// When `--bind` is omitted on the CLI, the server must honor `bind_address`
+/// from the config file. We verify this by reading the server's own
+/// "listening on …" log line from stderr and asserting it reports the
+/// config-supplied address. Inspecting the log avoids relying on aliased
+/// loopback addresses (e.g. 127.0.0.2), which are not portable across
+/// macOS and Linux.
+#[tokio::test]
+async fn test_e2e_bind_address_from_config_when_no_cli_flag() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let server_port = pick_unique_port(30000);
+    // Anything other than clap's old default ("127.0.0.1") distinguishes the
+    // fixed behavior from the bug. "0.0.0.0" is portable across OSes.
+    let bind_address = "0.0.0.0";
+
+    let data_dir = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_dir)?;
+    let config_path = temp_dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"data_dir = "{}"
+
+[server]
+bind_address = "{}"
+port = {}
+communication_timeout = 1
+"#,
+            data_dir.display(),
+            bind_address,
+            server_port,
+        ),
+    )?;
+
+    // Spawn the server WITHOUT --bind so the config's bind_address governs.
+    // The tracing-subscriber default writer is stdout, so we capture stdout
+    // and scan it for the "listening on …" line emitted by the server.
+    let mut child = TokioCommand::new(get_server_binary())
+        .args(["--mock", "--config", config_path.to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .kill_on_drop(true)
+        .spawn()?;
+
+    let stdout = child.stdout.take().expect("stdout piped");
+    let mut lines = TokioBufReader::new(stdout).lines();
+
+    let listening_line = timeout(SERVER_STARTUP_TIMEOUT, async {
+        while let Ok(Some(line)) = lines.next_line().await {
+            if line.contains("OpenFAN API Server listening on") {
+                return Some(line);
+            }
+        }
+        None
+    })
+    .await;
+
+    let _ = child.kill().await;
+    let _ = child.wait().await;
+
+    let line = listening_line
+        .map_err(|_| anyhow::anyhow!("timed out waiting for 'listening on' log line"))?
+        .ok_or_else(|| anyhow::anyhow!("server exited before logging 'listening on'"))?;
+
+    let expected = format!("{}:{}", bind_address, server_port);
+    assert!(
+        line.contains(&expected),
+        "expected server to bind to {} (from config), but log line was: {}",
+        expected,
+        line
+    );
+
+    Ok(())
+}
+

--- a/openfanctl/tests/e2e_integration_tests.rs
+++ b/openfanctl/tests/e2e_integration_tests.rs
@@ -1800,7 +1800,7 @@ async fn test_e2e_zone_with_controller_format() -> Result<()> {
 }
 
 // =============================================================================
-// Regression tests
+// Regression tests for issues #67 (bind from config) and #68 (controller flag)
 // =============================================================================
 
 /// Pick a unique port for a standalone test that does not use `E2ETestHarness`.
@@ -1820,6 +1820,30 @@ fn pick_unique_port(base: u16) -> u16 {
         .unwrap()
         .subsec_nanos();
     base + ((process_id + thread_num + nanos) % 1000) as u16
+}
+
+/// Poll an HTTP endpoint until it returns 2xx or the timeout expires.
+async fn wait_for_server(probe_url: &str) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()?;
+
+    let deadline = std::time::Instant::now() + SERVER_STARTUP_TIMEOUT;
+    let mut interval = Duration::from_millis(100);
+    while std::time::Instant::now() < deadline {
+        if let Ok(resp) = client.get(probe_url).send().await
+            && resp.status().is_success()
+        {
+            return Ok(());
+        }
+        sleep(interval).await;
+        interval = std::cmp::min(interval * 2, Duration::from_millis(500));
+    }
+    anyhow::bail!(
+        "Server at {} failed to respond within {:?}",
+        probe_url,
+        SERVER_STARTUP_TIMEOUT
+    );
 }
 
 /// Regression test for issue #67.
@@ -1898,3 +1922,127 @@ communication_timeout = 1
     Ok(())
 }
 
+/// Regression test for issue #68.
+///
+/// In multi-controller setups the CLI must honor `-c/--controller`. The bug
+/// hardcoded the controller path segment to `default`, so commands always
+/// targeted the wrong (non-existent) controller. We exercise this against
+/// a mock server with two non-default controllers: `controller-1` and
+/// `controller-2`.
+#[tokio::test]
+async fn test_e2e_cli_controller_flag_targets_specified_controller() -> Result<()> {
+    let temp_dir = tempfile::TempDir::new()?;
+    let server_port = pick_unique_port(31000);
+    let server_url = format!("http://127.0.0.1:{}", server_port);
+
+    let data_dir = temp_dir.path().join("data");
+    std::fs::create_dir_all(&data_dir)?;
+    let config_path = temp_dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            r#"data_dir = "{}"
+
+[server]
+bind_address = "127.0.0.1"
+port = {}
+communication_timeout = 1
+
+[[controllers]]
+id = "controller-1"
+device = "/dev/null"
+board = "standard"
+
+[[controllers]]
+id = "controller-2"
+device = "/dev/null"
+board = "standard"
+"#,
+            data_dir.display(),
+            server_port,
+        ),
+    )?;
+
+    let mut child = Command::new(get_server_binary())
+        .args(["--mock", "--config", config_path.to_str().unwrap()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    // Wait for the server (in mock + multi-controller mode) to be reachable.
+    let probe_url = format!("{}/api/v0/info", server_url);
+    if let Err(e) = wait_for_server(&probe_url).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(e);
+    }
+
+    let cli_binary = get_cli_binary();
+    let run_cli = |args: &[&str]| -> Result<std::process::Output> {
+        let mut full_args: Vec<&str> = vec!["--server", server_url.as_str(), "--no-config"];
+        full_args.extend(args.iter().copied());
+        Ok(Command::new(&cli_binary)
+            .args(&full_args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()?)
+    };
+
+    // 1. `-c controller-1 fan rpm 0` must succeed and emit RPM output.
+    let ok = run_cli(&["-c", "controller-1", "fan", "rpm", "0"])?;
+    let ok_stdout = String::from_utf8_lossy(&ok.stdout);
+    let ok_stderr = String::from_utf8_lossy(&ok.stderr);
+    assert!(
+        ok.status.success(),
+        "Expected -c controller-1 to succeed. stderr={}, stdout={}",
+        ok_stderr,
+        ok_stdout
+    );
+    assert!(
+        ok_stdout.contains("Fan 0 RPM"),
+        "Expected RPM output for controller-1, got: {}",
+        ok_stdout
+    );
+
+    // 2. Without -c the CLI must fall back to "default", which does not exist
+    //    in this multi-controller config, so the request must fail and the
+    //    error must surface the "default" path segment (the bug would have
+    //    *masked* the issue by silently hitting an unrelated controller).
+    let no_flag = run_cli(&["fan", "rpm", "0"])?;
+    assert!(
+        !no_flag.status.success(),
+        "Expected request without -c to fail in multi-controller setup"
+    );
+    let no_flag_err = format!(
+        "{}{}",
+        String::from_utf8_lossy(&no_flag.stdout),
+        String::from_utf8_lossy(&no_flag.stderr),
+    );
+    assert!(
+        no_flag_err.contains("controller/default"),
+        "Error should reference the 'default' controller path: {}",
+        no_flag_err
+    );
+
+    // 3. `-c bogus` must fail with the supplied id in the error path,
+    //    proving the flag value (not the constant "default") shapes the URL.
+    let bogus = run_cli(&["-c", "bogus", "fan", "rpm", "0"])?;
+    assert!(
+        !bogus.status.success(),
+        "Expected -c bogus to fail (controller does not exist)"
+    );
+    let bogus_err = format!(
+        "{}{}",
+        String::from_utf8_lossy(&bogus.stdout),
+        String::from_utf8_lossy(&bogus.stderr),
+    );
+    assert!(
+        bogus_err.contains("controller/bogus") || bogus_err.contains("bogus"),
+        "Error should reference the supplied controller id 'bogus': {}",
+        bogus_err
+    );
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}

--- a/openfand/src/main.rs
+++ b/openfand/src/main.rs
@@ -39,9 +39,9 @@ struct Args {
     #[arg(short, long)]
     config: Option<PathBuf>,
 
-    /// Server bind address
-    #[arg(short, long, default_value = "127.0.0.1")]
-    bind: String,
+    /// Server bind address (overrides `server.bind_address` from config file)
+    #[arg(short, long)]
+    bind: Option<String>,
 
     /// Server port
     #[arg(short, long)]
@@ -97,7 +97,11 @@ async fn main() -> Result<()> {
     // Get server config
     let server_config = &runtime_config.static_config().server;
     let port = args.port.unwrap_or(server_config.port);
-    let bind_addr = format!("{}:{}", args.bind, port);
+    let bind_host = args
+        .bind
+        .as_deref()
+        .unwrap_or(server_config.bind_address.as_str());
+    let bind_addr = format!("{}:{}", bind_host, port);
     let timeout_ms = server_config.communication_timeout * 1000;
     let reconnect_config = runtime_config.static_config().reconnect.clone();
 


### PR DESCRIPTION
Fix two long-standing config/CLI bugs in the daemon and CLI, plus add e2e regression tests for both.

## Issue #67 — bind address from config ignored

`openfand`'s `--bind` argument was declared with a clap default of `"127.0.0.1"`, then composed into `bind_addr`:

```rust
#[arg(short, long, default_value = "127.0.0.1")]
bind: String,
...
let bind_addr = format!("{}:{}", args.bind, port);
```

Because clap filled `args.bind` with `"127.0.0.1"` whenever the user didn't pass `--bind`, the code couldn't tell "user did not pass the flag" from "user passed `127.0.0.1`". The `server.bind_address` value from `config.toml` was loaded but never consulted — it was simply overwritten by the clap default. To bind to anything other than `127.0.0.1` you *had* to pass `--bind` on the CLI.

**Fix.** Make `--bind` an `Option<String>` with no default, and fall back to the config when it's `None`:

```rust
#[arg(short, long)]
bind: Option<String>,
...
let bind_host = args.bind.as_deref().unwrap_or(server_config.bind_address.as_str());
let bind_addr = format!("{}:{}", bind_host, port);
```

Precedence is now: CLI `--bind` > `server.bind_address` in config > `ServerConfig::default()` (`"127.0.0.1"`).

Closes #67.

## Issue #68 — CLI ignored -c/--controller

The `Cli` struct already declared a global `-c/--controller` flag, but `OpenFanClient` ignored it. Every controller-scoped URL was built from a hardcoded constant:

```rust
const DEFAULT_CONTROLLER: &'static str = "default";
...
let url = format!(
    "{}/api/v0/controller/{}/fan/status",
    self.base_url,
    Self::DEFAULT_CONTROLLER,   // always "default"
);
```

For a user with controllers named `controller-1` and `controller-2`, every `openfanctl fan …`, `profile …`, `alias …`, `curve …`, `cfm …` call went to `/api/v0/controller/default/…` and 404'd. The flag had no effect. `parse_zone_ports` also baked in the same `"default"` constant for unqualified ports in `zone add --ports`.

**Fix.** Move the controller id out of a constant and onto the client, then thread the CLI flag into it:

1. `OpenFanClient` gained a `controller_id: String` field (default `"default"`) plus `controller_id()` and `with_controller(id)` accessors.
2. Every URL and endpoint label in `client.rs` now interpolates `self.controller_id` instead of the constant — fan, profile, alias, curve, and CFM routes. Error messages reference the actual controller path, which makes 404s diagnosable.
3. `openfanctl/src/main.rs` applies the override right after constructing the client (`if let Some(id) = cli.controller.as_deref() { client.with_controller(id) }`).
4. `parse_zone_ports` now takes a `default_controller: &str` so unqualified ports in `-c controller-1 zone add --ports 0,1` resolve to `controller-1`, not the literal string `"default"`.

Single-controller users see no behavior change (the field still defaults to `"default"`, which matches the implicit controller the server creates in CLI/mock mode).

Closes #68.

## Tests

Two new e2e regression tests in `openfanctl/tests/e2e_integration_tests.rs`:

- `test_e2e_bind_address_from_config_when_no_cli_flag` — spawns `openfand --mock --config X` (no `--bind`) with `bind_address = "0.0.0.0"`, then scans the server's `OpenFAN API Server listening on …` log line on stdout and asserts it reports the config-supplied address. Verified to fail when the fix is reverted (log reports `127.0.0.1` instead of `0.0.0.0`).
- `test_e2e_cli_controller_flag_targets_specified_controller` — spawns a mock server with two `[[controllers]]` (`controller-1`, `controller-2`, no `default`), then asserts `-c controller-1 fan rpm 0` succeeds, no flag falls back to `controller/default` (404), and `-c bogus` surfaces `bogus` in the error path.

Full workspace suite: 484 tests passing (28 e2e, +2). Clippy clean.