### PR TITLE
ci: apply matrix-job naming conventions to workflows

### DIFF
--- a/.github/workflows/ci-compatibility-matrix.yml
+++ b/.github/workflows/ci-compatibility-matrix.yml
@@ -1,8 +1,8 @@
 # Compatibility testing: multi-version and multi-platform matrix.
 #
 # Local:
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-versions
-#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-all-platforms
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-rust-versions
+#   act push -W .github/workflows/ci-compatibility-matrix.yml -j test-platforms
 
 name: 'CI: Compatibility Matrix'
 
@@ -18,8 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-all-versions:
-    name: ubuntu-latest (${{ matrix.rust }})
+  test-rust-versions:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -62,8 +61,7 @@ jobs:
       - name: Test
         run: ./ci/test_full.sh
 
-  test-all-platforms:
-    name: ${{ matrix.target }}
+  test-platforms:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/ci-essentials.yml
+++ b/.github/workflows/ci-essentials.yml
@@ -23,14 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      matrix:
-        rust: [stable]
     steps:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: ${{ matrix.rust }}
+          toolchain: stable
           components: rustfmt, clippy
 
       - name: Checkout
@@ -51,7 +48,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-hash-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-stable-hash-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Quality – cargo fmt
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ concurrency:
 
 jobs:
   prepare-artifacts:
-    name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -115,7 +114,6 @@ jobs:
           retention-days: 1
 
   prepare-deb:
-    name: Build Debian package
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -164,7 +162,6 @@ jobs:
           retention-days: 1
 
   prepare-docker:
-    name: Build Docker image (${{ matrix.arch }})
     runs-on: ${{ matrix.os }}
     environment: release
     permissions:


### PR DESCRIPTION
Aligns the workflows with the github-actions playbook's matrix-job conventions: matrix jobs no longer set a `name:`, so GitHub renders each variant as `<job-key> (<matrix-values>)` and the YAML key stays visible in check names and logs.

Two generic keys in the compatibility matrix workflow are renamed to describe what they vary: `test-all-versions` → `test-rust-versions` and `test-all-platforms` → `test-platforms`. The local `act` examples in the file header are updated to match; nothing else (and no other workflow) referenced the old keys.

In the essentials workflow, the single-value `rust: [stable]` matrix is dropped from the `test` job and `stable` is inlined in the toolchain step and the cache key. The `test` job is no longer a matrix job, so its `name: Build & test` is preserved.

In the release workflow, the `name:` field is removed from the three matrix jobs (`prepare-artifacts`, `prepare-deb`, `prepare-docker`); their keys are already descriptive, so no renames were needed.