### PR TITLE
ci: change automerge strategy to squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "platformAutomerge": true,
-  "automergeStrategy": "merge-commit",
+  "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
   "packageRules": [
     {


### PR DESCRIPTION
Switch Renovate's automerge strategy from merge-commit to squash. Dependency update PRs will now land as single squashed commits instead of merge commits, keeping the main branch history linear.