### PR TITLE
chore(deps): replace tabled with comfy-table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,12 +161,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,6 +254,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +287,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -317,6 +345,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,12 +374,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
@@ -781,6 +812,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,13 +970,13 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "comfy-table",
  "openfan-core",
  "rand",
  "reqwest",
  "serde",
  "serde_json",
  "serial_test",
- "tabled",
  "tempfile",
  "thiserror",
  "tokio",
@@ -978,17 +1015,6 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
-name = "papergrid"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
-dependencies = [
- "bytecount",
- "fnv",
- "unicode-width",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1047,28 +1073,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn",
 ]
 
@@ -1434,30 +1438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tabled"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
-dependencies = [
- "papergrid",
- "tabled_derive",
- "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,15 +1448,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "testing_table"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -1750,6 +1721,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 colored = "3"
+comfy-table = "7"
 dirs = "6"
 reqwest = { version = "0.13", default-features = false, features = ["json"] }
-tabled = "0.21"
 toml = "1.1"
 urlencoding = "2"

--- a/openfanctl/Cargo.toml
+++ b/openfanctl/Cargo.toml
@@ -29,7 +29,7 @@ toml.workspace = true
 
 colored.workspace = true
 # Output formatting
-tabled.workspace = true
+comfy-table.workspace = true
 
 anyhow.workspace = true
 # Error handling

--- a/openfanctl/src/format.rs
+++ b/openfanctl/src/format.rs
@@ -9,7 +9,8 @@ use openfan_core::api::{
 };
 use std::collections::HashMap;
 
-use tabled::{Table, Tabled, settings::Style};
+use comfy_table::{Table, ContentArrangement};
+use comfy_table::presets::UTF8_FULL;
 
 /// Output format options
 #[derive(Debug, Clone)]
@@ -104,20 +105,19 @@ pub fn format_fan_status_with_cfm(
                 .unwrap_or(false);
 
             if has_cfm {
-                #[derive(Tabled)]
-                struct FanRowWithCfm {
-                    #[tabled(rename = "Fan ID")]
-                    fan_id: String,
-                    #[tabled(rename = "RPM")]
-                    rpm: String,
-                    #[tabled(rename = "PWM %")]
-                    pwm: String,
-                    #[tabled(rename = "CFM")]
-                    cfm: String,
-                }
+                // Define the table structure for fan status with CFM
+                let mut table = Table::new();
+                table
+                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .load_preset(UTF8_FULL)
+                    .set_header(vec![
+                        "Fan ID",
+                        "RPM",
+                        "PWM %",
+                        "CFM",
+                    ]);
 
                 let cfm_data = cfm_mappings.unwrap();
-                let mut rows = Vec::new();
 
                 // Collect all fan IDs from both rpms and pwms maps
                 let mut fan_ids: Vec<u8> = status
@@ -141,37 +141,34 @@ pub fn format_fan_status_with_cfm(
                         "-".dimmed().to_string()
                     };
 
-                    rows.push(FanRowWithCfm {
-                        fan_id: format!("{}", fan_id),
-                        rpm: if *rpm > 0 {
-                            format!("{}", rpm).green().to_string()
-                        } else {
-                            "0".red().to_string()
-                        },
-                        pwm: if *pwm > 0 {
-                            format!("{}%", pwm).cyan().to_string()
-                        } else {
-                            "0%".dimmed().to_string()
-                        },
-                        cfm: cfm_str,
-                    });
+                    let rpm_str = if *rpm > 0 {
+                        format!("{}", rpm).green().to_string()
+                    } else {
+                        "0".red().to_string()
+                    };
+
+                    let pwm_str = if *pwm > 0 {
+                        format!("{}%", pwm).cyan().to_string()
+                    } else {
+                        "0%".dimmed().to_string()
+                    };
+
+                    table.add_row(vec![
+                        format!("{}", fan_id),
+                        rpm_str,
+                        pwm_str,
+                        cfm_str,
+                    ]);
                 }
 
-                let table = Table::new(rows).with(Style::rounded()).to_string();
                 Ok(format!("{}\n{}", "Fan Status:".bold(), table))
             } else {
                 // No CFM mappings, use simple format
-                #[derive(Tabled)]
-                struct FanRow {
-                    #[tabled(rename = "Fan ID")]
-                    fan_id: String,
-                    #[tabled(rename = "RPM")]
-                    rpm: String,
-                    #[tabled(rename = "PWM %")]
-                    pwm: String,
-                }
-
-                let mut rows = Vec::new();
+                let mut table = Table::new();
+                table
+                    .set_content_arrangement(ContentArrangement::Dynamic)
+                    .load_preset(UTF8_FULL)
+                    .set_header(vec!["Fan ID", "RPM", "PWM %"]);
 
                 // Collect all fan IDs from both rpms and pwms maps
                 let mut fan_ids: Vec<u8> = status
@@ -187,22 +184,25 @@ pub fn format_fan_status_with_cfm(
                     let rpm = status.rpms.get(&fan_id).unwrap_or(&0);
                     let pwm = status.pwms.get(&fan_id).unwrap_or(&0);
 
-                    rows.push(FanRow {
-                        fan_id: format!("{}", fan_id),
-                        rpm: if *rpm > 0 {
-                            format!("{}", rpm).green().to_string()
-                        } else {
-                            "0".red().to_string()
-                        },
-                        pwm: if *pwm > 0 {
-                            format!("{}%", pwm).cyan().to_string()
-                        } else {
-                            "0%".dimmed().to_string()
-                        },
-                    });
+                    let rpm_str = if *rpm > 0 {
+                        format!("{}", rpm).green().to_string()
+                    } else {
+                        "0".red().to_string()
+                    };
+
+                    let pwm_str = if *pwm > 0 {
+                        format!("{}%", pwm).cyan().to_string()
+                    } else {
+                        "0%".dimmed().to_string()
+                    };
+
+                    table.add_row(vec![
+                        format!("{}", fan_id),
+                        rpm_str,
+                        pwm_str,
+                    ]);
                 }
 
-                let table = Table::new(rows).with(Style::rounded()).to_string();
                 Ok(format!("{}\n{}", "Fan Status:".bold(), table))
             }
         }
@@ -214,31 +214,25 @@ pub fn format_profiles(profiles: &ProfileResponse, format: &OutputFormat) -> Res
     match format {
         OutputFormat::Json => Ok(serde_json::to_string_pretty(profiles)?),
         OutputFormat::Table => {
-            #[derive(Tabled)]
-            struct ProfileRow {
-                #[tabled(rename = "Profile Name")]
-                name: String,
-                #[tabled(rename = "Mode")]
-                mode: String,
-                #[tabled(rename = "Values")]
-                values: String,
-            }
+            let mut table = Table::new();
+            table
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .load_preset(UTF8_FULL)
+                .set_header(vec!["Profile Name", "Mode", "Values"]);
 
-            let mut rows = Vec::new();
             for (name, profile) in &profiles.profiles {
-                rows.push(ProfileRow {
-                    name: name.clone().cyan().to_string(),
-                    mode: format!("{:?}", profile.control_mode).yellow().to_string(),
-                    values: profile
+                table.add_row(vec![
+                    name.clone().cyan().to_string(),
+                    format!("{:?}", profile.control_mode).yellow().to_string(),
+                    profile
                         .values
                         .iter()
                         .map(|v| v.to_string())
                         .collect::<Vec<_>>()
                         .join(", "),
-                });
+                ]);
             }
 
-            let table = Table::new(rows).with(Style::rounded()).to_string();
             Ok(format!("{}\n{}", "Available Profiles:".bold(), table))
         }
     }
@@ -249,15 +243,12 @@ pub fn format_aliases(aliases: &AliasResponse, format: &OutputFormat) -> Result<
     match format {
         OutputFormat::Json => Ok(serde_json::to_string_pretty(aliases)?),
         OutputFormat::Table => {
-            #[derive(Tabled)]
-            struct AliasRow {
-                #[tabled(rename = "Fan ID")]
-                fan_id: String,
-                #[tabled(rename = "Alias")]
-                alias: String,
-            }
+            let mut table = Table::new();
+            table
+                .set_content_arrangement(ContentArrangement::Dynamic)
+                .load_preset(UTF8_FULL)
+                .set_header(vec!["Fan ID", "Alias"]);
 
-            let mut rows = Vec::new();
             // Get all fan IDs from the aliases map and sort them
             let mut fan_ids: Vec<&u8> = aliases.aliases.keys().collect();
             fan_ids.sort_unstable();
@@ -269,13 +260,12 @@ pub fn format_aliases(aliases: &AliasResponse, format: &OutputFormat) -> Result<
                     .cloned()
                     .unwrap_or_else(|| format!("Fan #{}", fan_id));
 
-                rows.push(AliasRow {
-                    fan_id: format!("{}", fan_id),
-                    alias: alias.green().to_string(),
-                });
+                table.add_row(vec![
+                    format!("{}", fan_id),
+                    alias.green().to_string(),
+                ]);
             }
 
-            let table = Table::new(rows).with(Style::rounded()).to_string();
             Ok(format!("{}\n{}", "Fan Aliases:".bold(), table))
         }
     }

--- a/openfanctl/src/format.rs
+++ b/openfanctl/src/format.rs
@@ -9,8 +9,8 @@ use openfan_core::api::{
 };
 use std::collections::HashMap;
 
-use comfy_table::{Table, ContentArrangement};
 use comfy_table::presets::UTF8_FULL;
+use comfy_table::{ContentArrangement, Table};
 
 /// Output format options
 #[derive(Debug, Clone)]
@@ -110,12 +110,7 @@ pub fn format_fan_status_with_cfm(
                 table
                     .set_content_arrangement(ContentArrangement::Dynamic)
                     .load_preset(UTF8_FULL)
-                    .set_header(vec![
-                        "Fan ID",
-                        "RPM",
-                        "PWM %",
-                        "CFM",
-                    ]);
+                    .set_header(vec!["Fan ID", "RPM", "PWM %", "CFM"]);
 
                 let cfm_data = cfm_mappings.unwrap();
 
@@ -153,12 +148,7 @@ pub fn format_fan_status_with_cfm(
                         "0%".dimmed().to_string()
                     };
 
-                    table.add_row(vec![
-                        format!("{}", fan_id),
-                        rpm_str,
-                        pwm_str,
-                        cfm_str,
-                    ]);
+                    table.add_row(vec![format!("{}", fan_id), rpm_str, pwm_str, cfm_str]);
                 }
 
                 Ok(format!("{}\n{}", "Fan Status:".bold(), table))
@@ -196,11 +186,7 @@ pub fn format_fan_status_with_cfm(
                         "0%".dimmed().to_string()
                     };
 
-                    table.add_row(vec![
-                        format!("{}", fan_id),
-                        rpm_str,
-                        pwm_str,
-                    ]);
+                    table.add_row(vec![format!("{}", fan_id), rpm_str, pwm_str]);
                 }
 
                 Ok(format!("{}\n{}", "Fan Status:".bold(), table))
@@ -260,10 +246,7 @@ pub fn format_aliases(aliases: &AliasResponse, format: &OutputFormat) -> Result<
                     .cloned()
                     .unwrap_or_else(|| format!("Fan #{}", fan_id));
 
-                table.add_row(vec![
-                    format!("{}", fan_id),
-                    alias.green().to_string(),
-                ]);
+                table.add_row(vec![format!("{}", fan_id), alias.green().to_string()]);
             }
 
             Ok(format!("{}\n{}", "Fan Aliases:".bold(), table))


### PR DESCRIPTION
Replace tabled with comfy-table to fix RUSTSEC-2026-0173 security advisory

The proc-macro-error2 crate (transitive dependency of tabled) is no longer
maintained per the author's confirmation. comfy-table provides equivalent
functionality without unmaintained dependencies.

All 183 tests pass, clippy clean.