### PR TITLE
chore: standardize workspace verification and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ target/
 coverage/
 cobertura.xml
 
-AGENTS.md
 CLAUDE.md
 memory-bank/
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# AGENTS.md
+
+This file contains instructions for coding agents working in this repository.
+
+- Repository: <https://github.com/graelo/openfan-rs>
+- Prefer `gh` for GitHub operations.
+- Do not mention an agent or assistant in issues, pull requests, comments, or
+  commit messages.
+- Do not expose private local information, including machine-specific paths.
+
+## Project
+
+OpenFAN is a Rust workspace for controlling OpenFAN fan-controller hardware.
+It provides a REST API daemon and a command-line client:
+
+- `openfan-core`: shared types, API models, configuration, and error types.
+- `openfan-hardware`: serial transport and fan-controller protocol logic.
+- `openfand`: REST API server for hardware control and configuration.
+- `openfanctl`: CLI client for the server, with table and JSON output.
+
+The workspace uses Rust edition 2024 and supports the OpenFAN Standard board
+and custom boards with 1 to 16 fans. Hardware is detected automatically where
+possible; mock mode is available for development and testing.
+
+## Architecture
+
+1. `openfanctl` parses commands and sends HTTP requests to `openfand`.
+2. `openfand` validates requests, manages configuration, and exposes the REST
+   API under `/api/v0/`.
+3. `openfan-hardware` communicates with controllers over USB serial.
+4. `openfan-core` supplies the shared board, configuration, API, and error
+   models used by the other crates.
+
+Important areas:
+
+- `openfan-core/src/board.rs`: board types, fan counts, and board metadata.
+- `openfan-core/src/config/`: static configuration and mutable profiles,
+  aliases, zones, curves, and CFM mappings.
+- `openfan-hardware/src/`: serial transport and fan-controller protocol.
+- `openfand/src/api/`: REST routes, handlers, and application state.
+- `openfanctl/src/cli/`: command definitions and command handlers.
+- `openfanctl/tests/`: integration and end-to-end tests.
+
+## Verification
+
+The `Makefile` is the canonical definition of local build and verification
+tasks. **Read it before choosing or running verification commands**; do not
+duplicate command implementations here. `make help` lists every target.
+
+The primary targets are:
+
+- `make check`: formatting, linting, and the full test suite.
+- `make check-all`: `check` plus dependency, commit, Markdown, manpage, and
+  GitHub Actions security checks.
+- `make fix`: automatic rustfmt and Clippy fixes.
+- `make md`: Markdown linting using `rumdl.toml`.
+- `make man`: linting for both roff manpages.
+- `make ci-security`: Poutine and Zizmor GitHub Actions scans.
+
+The targets use locked Cargo dependency resolution where applicable and assume
+external tools such as `cargo-nextest`, `cargo-deny`, `cargo-pants`, `convco`,
+`poutine`, `zizmor`, `rumdl`, `mandoc`, and `cargo-llvm-cov` are installed.
+The complete test sequence is implemented in `ci/test_full.sh`.
+
+For focused tests, use `cargo nextest run -p <package>` or a specific test
+name. Doctests are run separately with `cargo test --doc --workspace`.
+
+## Documentation and releases
+
+Keep user-facing documentation synchronized with behavior:
+
+- Update `README.md` and `docs/TUTORIAL.md` when user-visible behavior or API
+  usage changes.
+- Update `man/openfand.1` or `man/openfanctl.1` when changing a CLI option,
+  default, command, or exit status. Lint them with `make man` and preview them
+  with `mandoc` as described in `CONTRIBUTING.md`.
+- Update the `.TH` version and date in both manpages for releases.
+- Update `Cargo.toml`, `Cargo.lock`, and `CHANGELOG.md` for releases.
+- Commit messages must follow `.convco`; use `make commits` to check them.
+
+Preserve the workspace structure, configuration paths, mock-mode behavior, and
+`--locked` behavior in Cargo commands that resolve dependencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,38 @@ All notable changes to the OpenFAN Controller project will be documented in
 this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.0 (2026-01-04)
+## [Unreleased]
 
 ### Added
 
-- **Makefile**: Convenience commands for building, testing, and Docker operations
-  - `make docker` automatically extracts version from Cargo.toml and builds Docker image
+- Manpages for the `openfand` and `openfanctl` binaries.
+- Makefile targets for local formatting, linting, testing, auditing, coverage,
+  and documentation checks.
+
+### Changed
+
+- Make the Makefile the canonical local verification workflow while retaining
+  OpenFAN's workspace, release, and Docker targets.
+- Move user-facing project documentation to `README.md` instead of duplicating
+  the overview in `openfan-core/src/lib.rs`.
+- Document the development and manpage workflows in `README.md` and
+  `CONTRIBUTING.md`.
+
+## [0.2.0] (2026-01-04)
+
+### Added
+
+- **Makefile**: Convenience commands for building, testing, and Docker
+    operations
+  - `make docker` automatically extracts version from Cargo.toml and builds
+    Docker image
   - `make docker-multiplatform` for multi-architecture builds (amd64/arm64)
   - `make build`, `make test`, `make clean` for standard Rust operations
-- **CONTRIBUTING.md**: Developer onboarding documentation with development setup,
-  testing guide, commit conventions, and PR process
+- **CONTRIBUTING.md**: Developer onboarding documentation with development
+    setup, testing guide, commit conventions, and PR process
 - Added specific error variants for better error handling: `ZoneNotFound`,
   `CurveNotFound`, `CfmMappingNotFound`
 - **Device reconnection support**: Automatic reconnection when hardware
@@ -38,24 +58,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configure multiple controllers via `[[controllers]]` array in config.toml
   - CLI `--controller` (`-c`) flag for controller-specific commands
   - New `openfanctl controllers` command to list all controllers
-  - New `openfanctl controller info <id>` and `controller reconnect <id>` subcommands
-  - Zones now support cross-controller fan grouping with `controller:fan_id` format
+  - New `openfanctl controller info <id>` and `controller reconnect <id>`
+    subcommands
+  - Zones now support cross-controller fan grouping with `controller:fan_id`
+    format
   - New API endpoints: `/api/v0/controllers`, `/api/v0/controller/{id}/info`,
     `/api/v0/controller/{id}/reconnect`
   - Backward compatible: single-controller setups work unchanged
 - **Code quality improvements**:
-  - `BoardType` enum now uses serde with string format (`"standard"`, `"custom:4"`)
+  - `BoardType` enum now uses serde with string format (`"standard"`,
+    `"custom:4"`)
   - Builder pattern for `ControllerEntry` construction
   - Removed duplicate type definitions across crates
   - Enhanced async method documentation with proper imperative mood
   - Minimized imports in openfanctl for better maintainability
   - Improved test coverage (183 integration tests, 75.21% code coverage)
-    - Added integration tests for edge cases in fan handlers (non-numeric IDs, missing controllers, PWM clamping)
+    - Added integration tests for edge cases in fan handlers (non-numeric IDs,
+      missing controllers, PWM clamping)
     - Added error conversion and Display trait tests in openfan-core
   - Version strings now use `env!("CARGO_PKG_VERSION")` for consistency
     - Replaced hardcoded version strings in production code
-    - Test fixtures also use CARGO_PKG_VERSION with "-test" suffix for mock server
-- **Module rename**: Renamed `openfand/src/hardware/` to `openfand/src/controllers/` for better alignment with multi-controller architecture
+    - Test fixtures also use CARGO_PKG_VERSION with "-test" suffix for mock
+      server
+- **Module rename**: Renamed `openfand/src/hardware/` to
+    `openfand/src/controllers/` for better alignment with multi-controller
+    architecture
 - **Docker version automation**:
   - Dockerfile now extracts version from Cargo.toml instead of hardcoding
   - docker-compose.yml passes VERSION build arg automatically
@@ -146,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/graelo/openfan-rs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/graelo/openfan-rs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/graelo/openfan-rs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/graelo/openfan-rs/releases/tag/v0.1.0
 [0.0.1]: https://github.com/graelo/openfan-rs/releases/tag/v0.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,221 +1,145 @@
 # Contributing to OpenFAN
 
-Thank you for your interest in contributing to OpenFAN! This document provides
-guidelines to help you get started.
+Thank you for your interest in contributing to OpenFAN.
 
 ## Development Environment Setup
 
-### Prerequisites
-
-- **Rust**: Install via [rustup](https://rustup.rs/) (stable toolchain)
-- **Git**: For version control
-- **Docker** (optional): For container builds and testing
-
-### Getting Started
+Install the stable Rust toolchain with [rustup](https://rustup.rs/). Docker is
+optional and is only needed for container builds and testing.
 
 ```bash
-# Clone the repository
 git clone https://github.com/graelo/openfan-rs.git
 cd openfan-rs
-
-# Build all crates
-cargo build
-# Or use make
 make build
-
-# Run tests to verify setup (requires cargo-nextest: cargo install cargo-nextest --locked)
-cargo nextest run --workspace
-# Or use make
-make test
 ```
 
-### Project Structure
+The workspace contains these crates:
 
 ```text
 openfan-rs/
-├── openfan-core/      # Shared types, API models, error types
-├── openfan-hardware/  # Serial communication, hardware protocol
+├── openfan-core/      # Shared types, API models, and configuration
+├── openfan-hardware/  # Serial communication and hardware protocol
 ├── openfand/          # REST API server (Axum)
-└── openfanctl/        # CLI client (clap)
+└── openfanctl/        # CLI client (clap + reqwest)
 ```
+
+## Verification
+
+The `Makefile` is the canonical definition of local build and verification
+tasks. Run `make help` to list every target.
+
+The primary targets are:
+
+- `make check`: formatting, linting, and the full test suite.
+- `make check-all`: `check` plus dependency, commit, documentation, and CI
+  security checks.
+- `make fix`: automatic rustfmt and Clippy fixes.
+- `make md`: Markdown linting using `rumdl.toml`.
+- `make man`: roff manpage linting.
+- `make coverage`: HTML coverage using `cargo-llvm-cov`.
+
+The verification targets assume that external tools such as
+`cargo-nextest`, `cargo-deny`, `cargo-pants`, `convco`, `poutine`, `zizmor`,
+`rumdl`, `mandoc`, and `cargo-llvm-cov` are installed locally.
+
+For focused Rust tests, use nextest directly:
+
+```bash
+cargo nextest run -p openfan-core
+cargo nextest run --test e2e_integration_tests -p openfanctl
+cargo test --doc --workspace
+```
+
+The complete test sequence, including the release-binary smoke tests, is in
+[`ci/test_full.sh`](ci/test_full.sh).
 
 ## Running the Project
 
-### Mock Mode (No Hardware Required)
+### Mock Mode
 
 ```bash
-# Start server in mock mode
+# Start the server without hardware
 cargo run -p openfand -- --mock --board standard
 
-# In another terminal, use the CLI
+# In another terminal
 cargo run -p openfanctl -- status
 ```
 
 ### With Hardware
 
 ```bash
-# Auto-detect OpenFAN Standard board
+# Auto-detect an OpenFAN Standard board
 cargo run -p openfand
 
-# Or specify device directly for custom boards
+# Specify a custom board and serial device
 cargo run -p openfand -- --device /dev/ttyACM0 --board custom:4
-```
-
-## Running Tests
-
-This project uses [cargo-nextest](https://nexte.st/) for running tests. Install
-it with `cargo install cargo-nextest --locked`.
-
-```bash
-# Run all tests (build first for e2e tests that use pre-built binaries)
-cargo build --workspace
-cargo nextest run --workspace
-# Or use make (builds automatically)
-make test
-
-# Run tests for a specific crate
-cargo nextest run -p openfan-core
-
-# Run unit tests only
-cargo nextest run --lib
-
-# Run end-to-end tests
-cargo nextest run --test e2e_integration_tests
-
-# Run doctests (cargo-nextest doesn't support doctests)
-cargo test --doc --workspace
-
-# Generate code coverage report
-# Note: Use --skip-clean to prevent tarpaulin from cleaning build artifacts
-# (needed for E2E tests that depend on compiled binaries)
-cargo tarpaulin --verbose --skip-clean -p openfand -p openfan-core -p openfan-hardware --timeout 120
 ```
 
 ## Docker Development
 
 ```bash
-# Build Docker image with version from Cargo.toml
 make docker
-
-# Build for multiple platforms (amd64/arm64)
 make docker-multiplatform
 
-# Test in Docker mock mode
 docker run -p 3000:3000 openfan:latest openfand --mock --board standard
-
-# Using docker-compose
-VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/') docker-compose up
 ```
 
-## Code Style Guidelines
+## Manpages
 
-- **Edition**: Rust 2024
-- **Formatting**: Use `cargo fmt` before committing
-- **Linting**: Run `cargo clippy` and address warnings
-- **Style**: Follow idiomatic Rust patterns
-- **Documentation**: Add doc comments for public APIs
+Manpages live in `man/` as roff source: `openfand.1` and `openfanctl.1`.
+
+Preview them with:
 
 ```bash
-# Format code
-cargo fmt
-
-# Run clippy
-cargo clippy --workspace --all-targets
+mandoc man/openfand.1 | less
+mandoc man/openfanctl.1 | less
 ```
 
-## Commit Message Conventions
+Lint both with:
 
-We use [Conventional Commits](https://www.conventionalcommits.org/) format:
+```bash
+make man
+```
+
+Update the relevant manpage when adding, removing, or renaming a CLI option,
+changing a default, or changing a command. Update the `.TH` version and date
+when preparing a release.
+
+## Code Style
+
+- Use Rust 2024 and stable Rust.
+- Run `make fmt` before committing.
+- Run `make lint` and address all warnings.
+- Add documentation for public APIs.
+- Follow idiomatic Rust naming and module structure.
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```text
 <type>: <description>
-
-[optional body]
 ```
 
-### Types
+Common types include `feat`, `fix`, `docs`, `refactor`, `test`, and `chore`.
+Run `make commits` to check commit messages against `.convco`.
 
-| Type | Description |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `docs` | Documentation changes |
-| `refactor` | Code refactoring (no functional change) |
-| `test` | Adding or updating tests |
-| `chore` | Maintenance tasks |
+## Pull Requests
 
-### Examples
-
-```text
-feat: add PWM curve configuration
-fix: correct fan speed calculation overflow
-docs: update API endpoint documentation
-refactor: extract board detection into separate module
-test: add integration tests for profile management
-chore: update dependencies
-```
-
-## Pull Request Process
-
-1. **Fork** the repository and create a feature branch:
-
-   ```bash
-   git checkout -b feat/your-feature-name
-   ```
-
-2. **Make your changes** following the code style guidelines
-
-3. **Test your changes**:
-
-   ```bash
-   cargo nextest run --workspace
-   cargo test --doc --workspace  # doctests not supported by nextest
-   cargo clippy --workspace --all-targets
-   cargo fmt --check
-   ```
-
-4. **Commit** with a descriptive message following conventions
-
-5. **Push** and open a pull request against `main`
-
-6. **Address review feedback** if requested
-
-### PR Guidelines
-
-- Keep PRs focused on a single change
-- Include tests for new functionality
-- Update documentation if needed
-- Ensure CI passes before requesting review
+1. Create a focused feature or fix branch.
+2. Update user-facing documentation when behavior changes.
+3. Run `make check` and, before opening a PR, `make check-all` when all local
+   audit tools are available.
+4. Commit with a Conventional Commit message.
+5. Open a pull request against `main`.
 
 ## Reporting Bugs
 
-When reporting bugs, please include:
-
-1. **Description**: Clear summary of the issue
-2. **Steps to reproduce**: Minimal steps to trigger the bug
-3. **Expected behavior**: What should happen
-4. **Actual behavior**: What happens instead
-5. **Environment**: OS, Rust version, hardware (if applicable)
-6. **Logs**: Relevant error messages or debug output
-
 Use the [GitHub Issues](https://github.com/graelo/openfan-rs/issues) tracker.
-
-## Feature Requests
-
-For feature requests:
-
-1. Check existing issues to avoid duplicates
-2. Describe the use case and motivation
-3. Propose a solution if you have one
-
-## Questions
-
-For questions about the codebase or development:
-
-- Open a [GitHub Discussion](https://github.com/graelo/openfan-rs/discussions)
-- Check existing documentation in `memory-bank/docs/`
+Include reproduction steps, expected and actual behavior, environment details,
+and relevant logs.
 
 ## License
 
 By contributing, you agree that your contributions will be licensed under the
-MIT License.
+MIT License or Apache License 2.0, at the project's option.

--- a/Makefile
+++ b/Makefile
@@ -1,50 +1,82 @@
-# OpenFAN Controller Makefile
-# Provides convenient commands for building, testing, and Docker operations
+# Local task runner for build, test, and pre-push / pre-PR verification.
+#
+# Usage:
+#   make check       # fmt + lint + test  (run before `git push`)
+#   make check-all   # adds audits, commit lint, docs, and CI security checks
+#   make fix         # auto-format and apply clippy fixes
+#
+# The check targets intentionally mirror the CI quality and test commands. They
+# assume their external tools (cargo-nextest, cargo-deny, cargo-pants, convco,
+# poutine, zizmor, rumdl, mandoc, and cargo-llvm-cov) are installed locally.
 
-# Extract version from Cargo.toml
+.DEFAULT_GOAL := help
+
 VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-
-# Docker image name
 DOCKER_IMAGE := openfan
 
-.PHONY: help build test clean docker docker-build docker-push
+.PHONY: help build fmt lint test check audit commits ci-security md man check-all \
+	fix release coverage clean docker docker-multiplatform docker-push
 
-help:
-	@echo "OpenFAN Controller v$(VERSION)"
-	@echo ""
-	@echo "Usage: make <target>"
-	@echo ""
-	@echo "Targets:"
-	@echo "  build        Build release binaries"
-	@echo "  test         Run all tests"
-	@echo "  clean        Clean build artifacts"
-	@echo "  docker       Build Docker image with version from Cargo.toml"
-	@echo "  docker-push  Push Docker image to registry"
-	@echo ""
-	@echo "Current version: $(VERSION)"
+help:  ## List available targets
+	@awk 'BEGIN {FS = ":.*## "} /^[a-zA-Z_-]+:.*## / \
+		{printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build:
-	cargo build --release
+build:  ## Build all workspace binaries in release mode
+	cargo build --locked --workspace --release
 
-test:
-	cargo build --workspace
-	cargo nextest run --workspace
+fmt:  ## rustfmt --check (no changes)
+	cargo fmt --all -- --check
 
-clean:
+lint:  ## clippy with warnings denied
+	cargo clippy --locked --workspace --all-targets --all-features -- -D warnings
+
+test:  ## full test suite (build + nextest + doc tests)
+	./ci/test_full.sh
+
+check: fmt lint test  ## pre-push gate: fmt + lint + test
+
+audit:  ## cargo-deny & cargo-pants: advisories, licenses, bans, sources
+	cargo deny --locked check
+	cargo pants
+
+commits:  ## verify commit messages follow Conventional Commits
+	convco check -c .convco
+
+ci-security:  ## audit GitHub Actions workflows
+	poutine --fail-on-violation analyze_local .
+	zizmor .github
+
+md:  ## lint Markdown against rumdl.toml
+	rumdl check .
+
+man:  ## lint the roff manpages
+	mandoc -Tlint man/openfand.1
+	mandoc -Tlint man/openfanctl.1
+
+check-all: check audit commits ci-security md man  ## pre-PR gate: everything
+
+fix:  ## auto-fix: rustfmt + clippy --fix
+	cargo fmt --all
+	cargo clippy --locked --workspace --all-targets --all-features --fix --allow-dirty --allow-staged -- -D warnings
+
+release:  ## release build with native CPU optimizations
+	RUSTFLAGS="-Ctarget-cpu=native" cargo build --locked --workspace --release
+
+coverage:  ## HTML coverage report at target/llvm-cov/html/index.html
+	cargo llvm-cov --locked --workspace --html
+
+clean:  ## Remove build artifacts
 	cargo clean
 
-# Build Docker image with version extracted from Cargo.toml
-docker:
+docker:  ## Build Docker image tagged with the Cargo version and latest
 	docker build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE):$(VERSION) -t $(DOCKER_IMAGE):latest .
 
-# Build for multiple platforms
-docker-multiplatform:
+docker-multiplatform:  ## Build Docker image for amd64 and arm64
 	docker buildx build --platform linux/amd64,linux/arm64 \
 		--build-arg VERSION=$(VERSION) \
 		-t $(DOCKER_IMAGE):$(VERSION) \
 		-t $(DOCKER_IMAGE):latest .
 
-# Push to registry (assumes docker login already done)
-docker-push:
+docker-push:  ## Push versioned and latest Docker images
 	docker push $(DOCKER_IMAGE):$(VERSION)
 	docker push $(DOCKER_IMAGE):latest

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ OpenFAN is a fan controller system consisting of:
 
 ## Supported Hardware
 
-| Board | Fans | USB VID:PID | Status |
-|-------|------|-------------|--------|
-| OpenFAN Standard | 10 | 2E8A:000A | Supported |
-| Custom | 1-16 | User-defined | Supported |
+| Board            | Fans | USB VID:PID  | Status    |
+| ---------------- | ---- | ------------ | --------- |
+| OpenFAN Standard | 10   | 2E8A:000A    | Supported |
+| Custom           | 1-16 | User-defined | Supported |
 
 The server auto-detects OpenFAN Standard boards via USB. For custom/DIY boards,
 use `--board custom:N` where N is the fan count (1-16).
@@ -50,7 +50,8 @@ curl -LO https://github.com/graelo/openfan-rs/releases/latest/download/openfan-c
 sudo dpkg -i openfan-controller_<VERSION>_amd64.deb
 ```
 
-**Other Linux** (statically-linked musl binaries — use `aarch64-unknown-linux-musl` on ARM64):
+**Other Linux** (statically-linked musl binaries — use
+`aarch64-unknown-linux-musl` on ARM64):
 
 ```bash
 BASE=https://github.com/graelo/openfan-rs/releases/latest/download
@@ -116,11 +117,11 @@ openfanctl --format json status
 
 OpenFAN discovers configuration using XDG paths with system fallback:
 
-| Type | User config | System config (fallback) |
-|------|--------------|----------------|
-| Server config | `~/.config/openfan/config.toml` | `/etc/openfan/config.toml` |
-| CLI config | `~/.config/openfan/cli.toml` | — |
-| Data (aliases, profiles, zones, curves) | `~/.local/share/openfan/` | `/var/lib/openfan/` |
+| Type                                    | User config                     | System config (fallback)   |
+| --------------------------------------- | ------------------------------- | -------------------------- |
+| Server config                           | `~/.config/openfan/config.toml` | `/etc/openfan/config.toml` |
+| CLI config                              | `~/.config/openfan/cli.toml`    | —                          |
+| Data (aliases, profiles, zones, curves) | `~/.local/share/openfan/`       | `/var/lib/openfan/`        |
 
 Config path priority: `--config` flag > `OPENFAN_SERVER_CONFIG` env var > XDG
 default.
@@ -240,6 +241,22 @@ curl -X POST http://localhost:3000/api/v0/controller/main/reconnect
 ```
 
 See the [Tutorial](docs/TUTORIAL.md) for the complete API reference.
+
+## Development
+
+The [`Makefile`](Makefile) is the canonical definition of local build and
+verification tasks. Run `make help` to list all targets. The primary workflow
+is:
+
+```bash
+make check       # formatting, linting, and the full test suite
+make check-all   # check plus audits, documentation, and CI security checks
+```
+
+Use `make fix` for automatic formatting and Clippy fixes. Manpages for the two
+binaries live in [`man/`](man/); lint them with `make man`. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for focused tests, coverage, and
+documentation maintenance.
 
 ## Docker
 

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -45,14 +45,14 @@ openfand --device /dev/ttyACM0 --board custom:4
 
 OpenFAN uses XDG-compliant paths by default:
 
-| File | Location | Purpose |
-|------|----------|---------|
-| Static config | `~/.config/openfan/config.toml` | Server settings |
-| Aliases | `~/.local/share/openfan/aliases.toml` | Fan names |
-| Profiles | `~/.local/share/openfan/profiles.toml` | Saved profiles |
-| Zones | `~/.local/share/openfan/zones.toml` | Fan groups |
+| File           | Location                                     | Purpose                |
+| -------------- | -------------------------------------------- | ---------------------- |
+| Static config  | `~/.config/openfan/config.toml`              | Server settings        |
+| Aliases        | `~/.local/share/openfan/aliases.toml`        | Fan names              |
+| Profiles       | `~/.local/share/openfan/profiles.toml`       | Saved profiles         |
+| Zones          | `~/.local/share/openfan/zones.toml`          | Fan groups             |
 | Thermal curves | `~/.local/share/openfan/thermal_curves.toml` | Temperature-PWM curves |
-| CFM mappings | `~/.local/share/openfan/cfm_mappings.toml` | Airflow display values |
+| CFM mappings   | `~/.local/share/openfan/cfm_mappings.toml`   | Airflow display values |
 
 For system-wide installations, use `/etc/openfan/` and `/var/lib/openfan/`.
 
@@ -221,12 +221,12 @@ openfanctl config reset
 CLI settings can also be configured via environment variables (override config
 file):
 
-| Variable | Purpose | Example |
-|----------|---------|---------|
-| `OPENFAN_SERVER` | Server URL | `http://192.168.1.100:3000` |
-| `OPENFAN_FORMAT` | Output format | `json` or `table` |
-| `OPENFAN_TIMEOUT` | Request timeout (seconds) | `30` |
-| `OPENFAN_VERBOSE` | Verbose output | `true` or `false` |
+| Variable          | Purpose                   | Example                     |
+| ----------------- | ------------------------- | --------------------------- |
+| `OPENFAN_SERVER`  | Server URL                | `http://192.168.1.100:3000` |
+| `OPENFAN_FORMAT`  | Output format             | `json` or `table`           |
+| `OPENFAN_TIMEOUT` | Request timeout (seconds) | `30`                        |
+| `OPENFAN_VERBOSE` | Verbose output            | `true` or `false`           |
 
 Priority: CLI flags > env vars > config file > defaults.
 
@@ -453,11 +453,11 @@ temperatures to PWM values, with linear interpolation between points.
 
 The server creates these default thermal curves:
 
-| Name | Description | Points |
-|------|-------------|--------|
-| Balanced | Standard curve for balanced performance | 30°C→25%, 50°C→50%, 70°C→80%, 85°C→100% |
-| Silent | Low noise curve for quiet operation | 40°C→20%, 60°C→40%, 80°C→70%, 90°C→100% |
-| Aggressive | High cooling for maximum performance | 30°C→40%, 50°C→70%, 65°C→90%, 75°C→100% |
+| Name       | Description                             | Points                                  |
+| ---------- | --------------------------------------- | --------------------------------------- |
+| Balanced   | Standard curve for balanced performance | 30°C→25%, 50°C→50%, 70°C→80%, 85°C→100% |
+| Silent     | Low noise curve for quiet operation     | 40°C→20%, 60°C→40%, 80°C→70%, 90°C→100% |
+| Aggressive | High cooling for maximum performance    | 30°C→40%, 50°C→70%, 65°C→90%, 75°C→100% |
 
 ### Managing Thermal Curves
 
@@ -612,35 +612,35 @@ The server exposes a REST API on port 3000 (default).
 
 ### Endpoints
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/v0/info` | GET | Server info (includes connection status) |
-| `/api/v0/reconnect` | POST | Trigger manual reconnection attempt |
-| `/api/v0/controllers` | GET | List all controllers |
-| `/api/v0/controller/{id}/info` | GET | Get controller details |
-| `/api/v0/controller/{id}/reconnect` | POST | Reconnect specific controller |
-| `/api/v0/fan/status` | GET | All fan status |
-| `/api/v0/fan/{id}/pwm?value=N` | GET | Set fan PWM (0-100) |
-| `/api/v0/fan/{id}/rpm?value=N` | GET | Set fan RPM target (500-9000) |
-| `/api/v0/profiles/list` | GET | List profiles |
-| `/api/v0/profiles/set?name=X` | GET | Apply profile |
-| `/api/v0/profiles/add` | POST | Add profile |
-| `/api/v0/alias/all/get` | GET | Get all aliases |
-| `/api/v0/alias/{id}/set?value=X` | GET | Set alias |
-| `/api/v0/alias/{id}` | DELETE | Delete alias (revert to default) |
-| `/api/v0/zones/list` | GET | List zones |
-| `/api/v0/zones/add` | POST | Add zone |
-| `/api/v0/zone/{name}/apply?mode=pwm&value=N` | GET | Apply to zone |
-| `/api/v0/curves/list` | GET | List thermal curves |
-| `/api/v0/curves/add` | POST | Add thermal curve |
-| `/api/v0/curve/{name}/get` | GET | Get curve details |
-| `/api/v0/curve/{name}/update` | POST | Update curve |
-| `/api/v0/curve/{name}` | DELETE | Delete curve |
-| `/api/v0/curve/{name}/interpolate?temp=N` | GET | Interpolate PWM for temperature |
-| `/api/v0/cfm/list` | GET | List CFM mappings |
-| `/api/v0/cfm/{port}` | GET | Get CFM mapping for port |
-| `/api/v0/cfm/{port}` | POST | Set CFM mapping `{"cfm_at_100": 45.0}` |
-| `/api/v0/cfm/{port}` | DELETE | Delete CFM mapping |
+| Endpoint                                     | Method | Description                              |
+| -------------------------------------------- | ------ | ---------------------------------------- |
+| `/api/v0/info`                               | GET    | Server info (includes connection status) |
+| `/api/v0/reconnect`                          | POST   | Trigger manual reconnection attempt      |
+| `/api/v0/controllers`                        | GET    | List all controllers                     |
+| `/api/v0/controller/{id}/info`               | GET    | Get controller details                   |
+| `/api/v0/controller/{id}/reconnect`          | POST   | Reconnect specific controller            |
+| `/api/v0/fan/status`                         | GET    | All fan status                           |
+| `/api/v0/fan/{id}/pwm?value=N`               | GET    | Set fan PWM (0-100)                      |
+| `/api/v0/fan/{id}/rpm?value=N`               | GET    | Set fan RPM target (500-9000)            |
+| `/api/v0/profiles/list`                      | GET    | List profiles                            |
+| `/api/v0/profiles/set?name=X`                | GET    | Apply profile                            |
+| `/api/v0/profiles/add`                       | POST   | Add profile                              |
+| `/api/v0/alias/all/get`                      | GET    | Get all aliases                          |
+| `/api/v0/alias/{id}/set?value=X`             | GET    | Set alias                                |
+| `/api/v0/alias/{id}`                         | DELETE | Delete alias (revert to default)         |
+| `/api/v0/zones/list`                         | GET    | List zones                               |
+| `/api/v0/zones/add`                          | POST   | Add zone                                 |
+| `/api/v0/zone/{name}/apply?mode=pwm&value=N` | GET    | Apply to zone                            |
+| `/api/v0/curves/list`                        | GET    | List thermal curves                      |
+| `/api/v0/curves/add`                         | POST   | Add thermal curve                        |
+| `/api/v0/curve/{name}/get`                   | GET    | Get curve details                        |
+| `/api/v0/curve/{name}/update`                | POST   | Update curve                             |
+| `/api/v0/curve/{name}`                       | DELETE | Delete curve                             |
+| `/api/v0/curve/{name}/interpolate?temp=N`    | GET    | Interpolate PWM for temperature          |
+| `/api/v0/cfm/list`                           | GET    | List CFM mappings                        |
+| `/api/v0/cfm/{port}`                         | GET    | Get CFM mapping for port                 |
+| `/api/v0/cfm/{port}`                         | POST   | Set CFM mapping `{"cfm_at_100": 45.0}`   |
+| `/api/v0/cfm/{port}`                         | DELETE | Delete CFM mapping                       |
 
 ### Example API Calls
 

--- a/man/openfanctl.1
+++ b/man/openfanctl.1
@@ -1,0 +1,275 @@
+.TH OPENFANCTL 1 "2026-08-20" "openfanctl 0.2.1" "User Commands"
+.SH NAME
+openfanctl \- command-line client for OpenFAN fan controllers
+.SH SYNOPSIS
+.B openfanctl
+.RI [ OPTIONS ] COMMAND
+.RI [ COMMAND_OPTIONS ]
+.SH DESCRIPTION
+.B openfanctl
+controls OpenFAN fan controllers through the REST API exposed by
+.BR openfand (1).
+It supports table and JSON output, configuration management, profiles,
+zones, thermal curves, and multi-controller setups.
+.SH GLOBAL OPTIONS
+.TP
+.BI \-s , \-\-server " " URL
+Server URL. Overrides the configured URL.
+.TP
+.BI \-f , \-\-format " " FORMAT
+Output format. FORMAT is
+.B table
+for pretty output or
+.B json
+for machine-readable JSON.
+.TP
+.BI \-v , \-\-verbose " " BOOL
+Enable or disable verbose logging. BOOL is
+.B true
+or
+.BR false .
+.TP
+.B \-\-no-config
+Do not load the CLI configuration file.
+.TP
+.BI \-\-config " " PATH
+CLI configuration file path. The default is
+.BR ~/.config/openfan/cli.toml .
+.TP
+.BI \-c , \-\-controller " " ID
+Controller ID for controller-specific commands.
+This is required for fan, profile, alias, curve, and CFM commands in
+multi-controller setups. Zone commands are global.
+.SH COMMANDS
+.TP
+.B info
+Show system information.
+.TP
+.B status
+Show the status of all fans.
+.TP
+.B health
+Check server connectivity and health.
+.TP
+.B controllers
+List all configured controllers.
+.TP
+.B controller
+Manage a specific controller. See
+.BR CONTROLLER .
+.TP
+.B config
+Show or manage CLI configuration. See
+.BR CONFIG .
+.TP
+.B fan
+Control or inspect a fan. See
+.BR FAN .
+.TP
+.B profile
+Manage fan profiles. See
+.BR PROFILE .
+.TP
+.B alias
+Manage fan aliases. See
+.BR ALIAS .
+.TP
+.B zone
+Manage global, cross-controller zones. See
+.BR ZONE .
+.TP
+.B curve
+Manage thermal curves. See
+.BR CURVE .
+.TP
+.B cfm
+Manage CFM mappings. See
+.BR CFM .
+.TP
+.BI completion " " SHELL
+Generate shell completion for
+.BR bash ,
+.BR elvish ,
+.BR fish ,
+.BR powershell ,
+or
+.BR zsh .
+.SH CONTROLLER
+.TP
+.BI controller info " " ID
+Show information for controller ID.
+.TP
+.BI controller reconnect " " ID
+Force a reconnection attempt for controller ID.
+.SH CONFIG
+.TP
+.B config show
+Show the current CLI configuration.
+.TP
+.BI config set " " KEY VALUE
+Set a configuration value.
+.TP
+.B config reset
+Reset CLI configuration to defaults.
+.SH FAN
+.TP
+.BI fan set " " FAN_ID
+Set a fan speed. Specify exactly one of the following options:
+.TP
+.BI \-\-pwm " " PERCENT
+Set PWM percentage from 0 to 100.
+.TP
+.BI \-\-rpm " " RPM
+Set a target RPM.
+.TP
+.BI fan rpm " " FAN_ID
+Get the current RPM for a fan.
+.TP
+.BI fan pwm " " FAN_ID
+Get the current PWM for a fan.
+.SH PROFILE
+.TP
+.B profile list
+List all profiles.
+.TP
+.BI profile apply " " NAME
+Apply a profile.
+.TP
+.BI profile add " " NAME MODE VALUES
+Add a profile. MODE is
+.B pwm
+or
+.BR rpm .
+VALUES is a comma-separated list of values for the board's fan channels.
+.TP
+.BI profile remove " " NAME
+Remove a profile.
+.SH ALIAS
+.TP
+.B alias list
+Show all fan aliases.
+.TP
+.BI alias get " " FAN_ID
+Get the alias for a fan.
+.TP
+.BI alias set " " FAN_ID NAME
+Set a fan alias.
+.TP
+.BI alias delete " " FAN_ID
+Delete a fan alias and restore its default name.
+.SH ZONE
+Zones are global and may contain fans from multiple controllers.
+A port is written as
+.B controller:fan_id
+or as
+.B fan_id
+to use the default controller.
+.TP
+.B zone list
+List all zones.
+.TP
+.BI zone get " " NAME
+Show zone details.
+.TP
+.BI zone add " " NAME
+Add a zone. Use
+.BI \-p , \-\-ports " " PORTS
+for comma-separated port specifications and optionally
+.BI \-d , \-\-description " " DESCRIPTION .
+.TP
+.BI zone update " " NAME
+Update a zone using the same
+.B \-\-ports
+and optional
+.B \-\-description
+options as
+.BR zone add .
+.TP
+.BI zone delete " " NAME
+Delete a zone.
+.TP
+.BI zone apply " " NAME
+Apply a value to every fan in a zone. Specify
+.BI \-\-pwm " " PERCENT
+or
+.BI \-\-rpm " " RPM .
+.SH CURVE
+.TP
+.B curve list
+List all thermal curves.
+.TP
+.BI curve get " " NAME
+Show thermal curve details.
+.TP
+.BI curve add " " NAME
+Add a thermal curve with
+.BI \-p , \-\-points " " POINTS
+where POINTS has the form
+.BR temp:pwm,temp:pwm,... .
+Optionally provide
+.BI \-d , \-\-description " " DESCRIPTION .
+.TP
+.BI curve update " " NAME
+Update a thermal curve using the same options as
+.BR curve add .
+.TP
+.BI curve delete " " NAME
+Delete a thermal curve.
+.TP
+.BI curve interpolate " " NAME
+Interpolate a PWM value at a temperature supplied with
+.BI \-t , \-\-temp " " CELSIUS .
+.SH CFM
+CFM mappings provide display-only airflow estimates for fan ports.
+.TP
+.B cfm list
+List all CFM mappings.
+.TP
+.BI cfm get " " PORT
+Get the CFM mapping for a port.
+.TP
+.BI cfm set " " PORT
+Set the CFM-at-100-percent value with
+.BI \-\-cfm-at-100 " " CFM .
+.TP
+.BI cfm delete " " PORT
+Delete the CFM mapping for a port.
+.SH EXAMPLES
+Show status as JSON:
+.PP
+.nf
+openfanctl --format json status
+.fi
+.PP
+Set fan 0 to 75 percent PWM:
+.PP
+.nf
+openfanctl fan set 0 --pwm 75
+.fi
+.PP
+Use a specific controller:
+.PP
+.nf
+openfanctl --controller gpu fan set 0 --rpm 1200
+.fi
+.PP
+Add a cross-controller zone:
+.PP
+.nf
+openfanctl zone add intake --ports main:0,main:1,gpu:0
+.fi
+.SH FILES
+.TP
+.I ~/.config/openfan/cli.toml
+Default CLI configuration file.
+.SH EXIT STATUS
+.TP
+.B 0
+The requested operation completed successfully.
+.TP
+.B 1
+The operation failed or the server returned an error.
+.SH SEE ALSO
+.BR openfand (1)
+.SH AUTHORS
+graelo <https://github.com/graelo/openfan-rs>

--- a/man/openfand.1
+++ b/man/openfand.1
@@ -1,0 +1,113 @@
+.TH OPENFAND 1 "2026-08-20" "openfand 0.2.1" "User Commands"
+.SH NAME
+openfand \- REST API server for OpenFAN fan controllers
+.SH SYNOPSIS
+.B openfand
+.RI [ OPTIONS ]
+.SH DESCRIPTION
+.B openfand
+runs the OpenFAN REST API server and communicates with one or more fan
+controllers over USB serial.
+.PP
+A controller can be configured through command-line options for a single
+controller, or through one or more
+.B [[controllers]]
+entries in the TOML configuration file.
+Mock mode provides a server without hardware for development and testing.
+.SH OPTIONS
+.TP
+.BI \-c , \-\-config " " PATH
+Path to the TOML configuration file.
+The default is selected from
+.BR OPENFAN_SERVER_CONFIG ,
+XDG configuration directories, and the platform configuration directory.
+.TP
+.BI \-b , \-\-bind " " ADDRESS
+Server bind address. Overrides
+.B server.bind_address
+from the configuration file.
+.TP
+.BI \-p , \-\-port " " PORT
+Server port. Overrides
+.B server.port
+from the configuration file.
+.TP
+.BR \-v , \-\-verbose
+Enable verbose logging.
+.TP
+.B \-\-mock
+Run without hardware for testing and development.
+When no controllers are configured, this creates a single
+.B default
+controller using
+.BR \-\-board .
+.TP
+.BI \-\-board " " BOARD
+Board type for single-controller mode.
+Use
+.B standard
+for the OpenFAN Standard board or
+.B custom:N
+for a custom board with 1 to 16 fans.
+The default is
+.BR standard .
+This option is ignored when
+.B [[controllers]]
+is configured.
+.TP
+.BI \-\-device " " PATH
+Serial device path, such as
+.B /dev/ttyACM0
+or
+.BR /dev/ttyUSB0 .
+Creates an implicit
+.B default
+controller in single-controller mode and takes precedence over configured
+controllers.
+.SH CONFIGURATION
+The server reads TOML configuration containing server settings, mutable data
+location, reconnection and shutdown behavior, and optional controller entries.
+.PP
+A multi-controller configuration uses entries like:
+.PP
+.nf
+[[controllers]]
+id = "main"
+device = "/dev/ttyACM0"
+board = "standard"
+description = "Main chassis fans"
+.fi
+.PP
+When no controller is configured, use either
+.B \-\-device
+with
+.B \-\-board
+or
+.B \-\-mock
+with
+.BR \-\-board .
+.SH FILES
+.TP
+.I ~/.config/openfan/config.toml
+Default per-user server configuration on Linux.
+.TP
+.I /etc/openfan/config.toml
+System-wide fallback configuration.
+.TP
+.I ~/.config/openfan/
+Platform-dependent configuration directory selected through XDG conventions.
+.TP
+.I /var/lib/openfan/
+System-wide default directory for mutable profiles, aliases, zones, curves,
+and CFM mappings.
+.SH EXIT STATUS
+.TP
+.B 0
+The server terminated successfully.
+.TP
+.B 1
+Configuration loading, controller initialization, or runtime startup failed.
+.SH SEE ALSO
+.BR openfanctl (1)
+.SH AUTHORS
+graelo <https://github.com/graelo/openfan-rs>

--- a/openfan-core/src/lib.rs
+++ b/openfan-core/src/lib.rs
@@ -1,8 +1,3 @@
-//! OpenFAN Core Library
-//!
-//! Shared types, models, and utilities for the OpenFAN Controller project.
-//! This crate is used by both the server and CLI components.
-
 pub mod api;
 pub mod board;
 pub mod config;

--- a/rumdl.toml
+++ b/rumdl.toml
@@ -1,0 +1,17 @@
+# See the lints at https://github.com/rvben/rumdl/tree/main/docs
+[global]
+flavor = "mkdocs"
+disable = [
+  "MD007",  # prefer the flavor over MD007
+  "MD046",  # allow code blocks to be indented and fenced
+]
+
+[MD013]
+line-length = 80
+code-blocks = false
+tables = false
+reflow = true
+
+[MD060]
+enabled = true
+style = "aligned"


### PR DESCRIPTION
Consolidate local build and verification workflows in the Makefile, including workspace-aware Rust checks, audits, Markdown and manpage linting, coverage, and preserved Docker targets. Add manpages for `openfand` and `openfanctl`, and align the README, contributor guidance, agent guidance, tutorial, and changelog with the workflow. Remove duplicated crate-level overview documentation from `openfan-core` and track `AGENTS.md` directly.
